### PR TITLE
update license in cargo toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 repository = "https://github.com/PSeitz/rust_measure_time"
 homepage = "https://github.com/PSeitz/rust_measure_time"
 keywords = ["measure", "time", "elapsed", "wall", "humantime"]
-license = "Unlicense"
+license = "MIT"
 description = """
 Provices macros to measure the time until end of scope.
 """


### PR DESCRIPTION
The LICENSE file contents is MIT but the cargo.toml license field is Unlicense.

This PR brings the cargo toml field in line with the more recent license file